### PR TITLE
Add insulin resistance calculations to results page

### DIFF
--- a/app.py
+++ b/app.py
@@ -237,6 +237,27 @@ def final():
 
     # Sort rows by priority and then name
     final_rows.sort(key=sort_priority)
+    # Helper to pull numeric values for specific tests
+    def get_numeric(test_name):
+        for r in final_rows:
+            if r["TestName"].casefold() == test_name.casefold():
+                try:
+                    return float(re.sub(r"[^0-9.\-]", "", r["ObservedValue"]))
+                except Exception:
+                    return None
+        return None
+
+    triglycerides = get_numeric("Triglycerides")
+    hdl = get_numeric("HDL Cholesterol")
+    insulin = get_numeric("Insulin")
+    glucose = get_numeric("Glucose")
+    a1c = get_numeric("Hemoglobin A1c")
+
+    insulin_metrics = {
+        "trig_hdl_ratio": round(triglycerides / hdl, 2) if triglycerides is not None and hdl not in [None, 0] else None,
+        "homa_ir": round((insulin * glucose) / 405, 2) if insulin is not None and glucose is not None else None,
+        "estimated_average_glucose": round(28.7 * a1c - 46.7, 2) if a1c is not None else None,
+    }
 
     # Return the rendered template
     test_data = defaultdict(lambda: defaultdict(list))
@@ -248,5 +269,5 @@ def final():
             if not v.strip() or v.casefold() == 'n/a':
                 v = None
             test_data[test][k].append(v)
-    return render_template('finaltable.html.j2', rows=final_rows, year=datetime.now().year, testData=test_data)
+    return render_template('finaltable.html.j2', rows=final_rows, year=datetime.now().year, testData=test_data, insulin_metrics=insulin_metrics)
 

--- a/templates/finaltable.html.j2
+++ b/templates/finaltable.html.j2
@@ -134,6 +134,31 @@
       background-color: #e5f0ff;
     }
 
+    .metrics-section {
+      background: #ffffff;
+      border-radius: 16px;
+      box-shadow: 0 4px 20px rgba(0, 59, 89, .15);
+      padding: 20px;
+      margin-bottom: 40px;
+    }
+    .metrics-section h2 {
+      color: #003b59;
+      font-size: 1.5em;
+      margin-top: 0;
+      margin-bottom: 15px;
+      text-align: center;
+    }
+    .metrics-section ul {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+    }
+    .metrics-section li {
+      padding: 6px 0;
+      text-align: center;
+      font-size: 1em;
+    }
+
     /* Add chart section styles */
     .chart-section {
       margin-top: 60px;
@@ -198,6 +223,15 @@
   <a href="javascript:history.back()">Go Back/Review PDF Results</a>
   <a href="/">Start Over with New Files</a>
   <a href="#" onclick="exportToCSV()" id="exportBtn">Export to CSV</a>
+</div>
+
+<div class="metrics-section">
+  <h2>Insulin Resistance Measures</h2>
+  <ul>
+    <li>Triglyceride to HDL ratio: {{ insulin_metrics.trig_hdl_ratio if insulin_metrics.trig_hdl_ratio is not none else 'calculation unavailable' }}</li>
+    <li>HOMA-IR: {{ insulin_metrics.homa_ir if insulin_metrics.homa_ir is not none else 'calculation unavailable' }}</li>
+    <li>Estimated Average Glucose: {{ insulin_metrics.estimated_average_glucose if insulin_metrics.estimated_average_glucose is not none else 'calculation unavailable' }}</li>
+  </ul>
 </div>
 
 <table id="resultsTable">


### PR DESCRIPTION
## Summary
- compute triglyceride/HDL ratio, HOMA-IR, and estimated average glucose in `final()`
- display calculated insulin resistance metrics on final results table with graceful fallbacks

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_b_6899589560f483249a7c5c7191864b66